### PR TITLE
Forward room key request & response

### DIFF
--- a/crypto/decryptmegolm.go
+++ b/crypto/decryptmegolm.go
@@ -56,18 +56,9 @@ func (mach *OlmMachine) DecryptMegolmEvent(evt *event.Event) (*event.Event, erro
 	if content.DeviceID == mach.Client.DeviceID && sess.SigningKey == ownSigningKey && content.SenderKey == ownIdentityKey {
 		verified = true
 	} else {
-		device, err := mach.CryptoStore.GetDevice(evt.Sender, content.DeviceID)
+		device, err := mach.getOrFetchDevice(evt.Sender, content.DeviceID)
 		if err != nil {
-			return nil, errors.Wrap(err, "failed to get sender device from store")
-		} else if device == nil {
-			usersToDevices := mach.fetchKeys([]id.UserID{evt.Sender}, "", true)
-			if devices, ok := usersToDevices[evt.Sender]; ok {
-				if device, ok = devices[content.DeviceID]; !ok {
-					return nil, errors.Errorf("failed to get identity for device %v", content.DeviceID)
-				}
-			} else {
-				return nil, errors.Errorf("Error fetching devices for user %v", evt.Sender)
-			}
+			return nil, err
 		}
 		if device.Trust == TrustStateVerified && len(sess.ForwardingChains) == 0 { // For some reason, matrix-nio had a comment saying not to events decrypted using a forwarded key as verified.
 			if device.SigningKey != sess.SigningKey || device.IdentityKey != content.SenderKey {

--- a/crypto/keysharing.go
+++ b/crypto/keysharing.go
@@ -1,0 +1,186 @@
+// Copyright (c) 2020 Nikos Filippakis
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package crypto
+
+import (
+	"context"
+	"math/rand"
+	"strconv"
+
+	"maunium.net/go/mautrix/crypto/olm"
+	"maunium.net/go/mautrix/id"
+
+	"maunium.net/go/mautrix"
+	"maunium.net/go/mautrix/event"
+)
+
+// RequestRoomKey sends a key request for a room to the current user's devices. If the context is cancelled, then so is the key request.
+// Returns a bool channel that will get notified either when the key is received or the request is cancelled.
+func (mach *OlmMachine) RequestRoomKey(ctx context.Context, toUser id.UserID, toDevice id.DeviceID,
+	roomID id.RoomID, senderKey id.SenderKey, sessionID id.SessionID) (chan bool, error) {
+
+	requestID := strconv.Itoa(rand.Int())
+	keyResponseReceived := make(chan struct{})
+	// store the channel where we will be notified about responses for this session ID
+	mach.roomKeyRequestFilled.Store(sessionID, keyResponseReceived)
+	// request the keys for this session
+	reqEvtContent := &event.Content{
+		Parsed: event.RoomKeyRequestEventContent{
+			Action: event.KeyRequestActionRequest,
+			Body: event.RequestedKeyInfo{
+				Algorithm: id.AlgorithmMegolmV1,
+				RoomID:    roomID,
+				SenderKey: senderKey,
+				SessionID: sessionID,
+			},
+			RequestID:          requestID,
+			RequestingDeviceID: mach.Client.DeviceID,
+		},
+	}
+
+	toDeviceReq := &mautrix.ReqSendToDevice{
+		Messages: map[id.UserID]map[id.DeviceID]*event.Content{
+			toUser: {
+				toDevice: reqEvtContent,
+			},
+		},
+	}
+	// send messages to the devices
+	if _, err := mach.Client.SendToDevice(event.ToDeviceRoomKeyRequest, toDeviceReq); err != nil {
+		return nil, err
+	}
+	resChan := make(chan bool, 1)
+	go func() {
+		select {
+		case <-keyResponseReceived:
+			// key request successful
+			mach.Log.Debug("Key for session %v was received, cancelling other key requests", sessionID)
+			resChan <- true
+		case <-ctx.Done():
+			// if the context is done, key request was unsuccessful
+			mach.Log.Debug("Context closed (%v) before forwared key for session %v received, sending key request cancellation", ctx.Err(), sessionID)
+			resChan <- false
+		}
+
+		// send a message to all devices cancelling this key request
+		mach.roomKeyRequestFilled.Delete(sessionID)
+
+		cancelEvtContent := &event.Content{
+			Parsed: event.RoomKeyRequestEventContent{
+				Action:             event.KeyRequestActionCancel,
+				RequestID:          requestID,
+				RequestingDeviceID: mach.Client.DeviceID,
+			},
+		}
+
+		toDeviceCancel := &mautrix.ReqSendToDevice{
+			Messages: map[id.UserID]map[id.DeviceID]*event.Content{
+				toUser: {
+					toDevice: cancelEvtContent,
+				},
+			},
+		}
+
+		mach.Client.SendToDevice(event.ToDeviceRoomKeyRequest, toDeviceCancel)
+	}()
+	return resChan, nil
+}
+
+func (mach *OlmMachine) importForwardedRoomKey(evt *DecryptedOlmEvent, content *event.ForwardedRoomKeyEventContent) bool {
+	if content.Algorithm != id.AlgorithmMegolmV1 || evt.Keys.Ed25519 == "" {
+		return false
+	}
+
+	roomID := content.RoomID
+	senderKey := evt.SenderKey
+	origSenderKey := content.SenderKey
+	sessionID := content.SessionID
+
+	igsInternal, err := olm.InboundGroupSessionImport([]byte(content.SessionKey))
+	igs := &InboundGroupSession{
+		Internal:         *igsInternal,
+		SigningKey:       evt.Keys.Ed25519,
+		SenderKey:        origSenderKey,
+		RoomID:           roomID,
+		ForwardingChains: append(content.ForwardingKeyChain, senderKey.String()),
+		id:               sessionID,
+	}
+	if err != nil {
+		mach.Log.Error("Failed to import inbound group session: %v", err)
+		return false
+	} else if igs.ID() != content.SessionID {
+		mach.Log.Warn("Mismatched session ID while creating inbound group session")
+		return false
+	}
+	err = mach.CryptoStore.PutGroupSession(roomID, origSenderKey, sessionID, igs)
+	if err != nil {
+		mach.Log.Error("Failed to store new inbound group session: %v", err)
+		return false
+	}
+	mach.Log.Trace("Created inbound group session %s/%s/%s", roomID, origSenderKey, sessionID)
+	return true
+}
+
+func (mach *OlmMachine) handleRoomKeyRequest(sender id.UserID, content *event.RoomKeyRequestEventContent, allowUnverified bool) {
+	// Only forward keys to the same user ID
+	if content.Action == event.KeyRequestActionRequest && mach.Client.UserID == sender {
+		if content.RequestingDeviceID == mach.Client.DeviceID {
+			mach.Log.Debug("Ignoring key request from the same device (%v)", content.RequestingDeviceID)
+			return
+		}
+		mach.Log.Debug("Received key request from %v for session %v", content.RequestingDeviceID, content.Body.SessionID)
+
+		// fetch requesting device identity
+		device, err := mach.getOrFetchDevice(sender, content.RequestingDeviceID)
+		if err != nil {
+			mach.Log.Error("Error getting key requesting device: %v", err)
+			return
+		}
+		// ignore if not verified and we do not allow unverified
+		if device.Trust != TrustStateVerified && !allowUnverified {
+			mach.Log.Warn("Device %v requesting room keys is not verified, ignoring", device.DeviceID)
+			return
+		}
+
+		igs, err := mach.CryptoStore.GetGroupSession(content.Body.RoomID, content.Body.SenderKey, content.Body.SessionID)
+		if err != nil {
+			mach.Log.Error("Error retrieving IGS to forward key: %v", err)
+			return
+		}
+		if igs == nil {
+			mach.Log.Warn("Can't find the requested session to forward: %v", content.Body.SessionID)
+			return
+		}
+
+		// export session key at earliest index
+		exportedKey, err := igs.Internal.Export(igs.Internal.FirstKnownIndex())
+		if err != nil {
+			mach.Log.Error("Error exporting key for session %v: %v", igs.ID(), err)
+			return
+		}
+
+		forwardedRoomKey := event.Content{
+			Parsed: &event.ForwardedRoomKeyEventContent{
+				RoomKeyEventContent: event.RoomKeyEventContent{
+					Algorithm:  id.AlgorithmMegolmV1,
+					RoomID:     igs.RoomID,
+					SessionID:  igs.ID(),
+					SessionKey: exportedKey,
+				},
+				SenderKey:          content.Body.SenderKey,
+				ForwardingKeyChain: igs.ForwardingChains,
+				SenderClaimedKey:   igs.SigningKey,
+			},
+		}
+
+		if err := mach.SendEncryptedToDevice(device, forwardedRoomKey); err != nil {
+			mach.Log.Error("Failed to send encrypted forwarded key: %v", err)
+		}
+
+		mach.Log.Debug("Sent encrypted forwarded key to device %v for session %v", content.RequestingDeviceID, igs.ID())
+	}
+}

--- a/crypto/olm/inboundgroupsession.go
+++ b/crypto/olm/inboundgroupsession.go
@@ -262,8 +262,8 @@ func (s *InboundGroupSession) ID() id.SessionID {
 }
 
 // FirstKnownIndex returns the first message index we know how to decrypt.
-func (s *InboundGroupSession) FirstKnownIndex() uint {
-	return uint(C.olm_inbound_group_session_first_known_index((*C.OlmInboundGroupSession)(s.int)))
+func (s *InboundGroupSession) FirstKnownIndex() uint32 {
+	return uint32(C.olm_inbound_group_session_first_known_index((*C.OlmInboundGroupSession)(s.int)))
 }
 
 // IsVerified check if the session has been verified as a valid session.  (A

--- a/crypto/sql_store.go
+++ b/crypto/sql_store.go
@@ -356,6 +356,8 @@ func (store *SQLCryptoStore) GetDevice(userID id.UserID, deviceID id.DeviceID) (
 		}
 		return nil, err
 	}
+	identity.UserID = userID
+	identity.DeviceID = deviceID
 	return &identity, nil
 }
 

--- a/event/encryption.go
+++ b/event/encryption.go
@@ -94,8 +94,9 @@ type RoomKeyEventContent struct {
 // https://matrix.org/docs/spec/client_server/r0.6.0#m-forwarded-room-key
 type ForwardedRoomKeyEventContent struct {
 	RoomKeyEventContent
-	SenderClaimedKey   string   `json:"sender_claimed_ed25519_key"`
-	ForwardingKeyChain []string `json:"forwarding_curve25519_key_chain"`
+	SenderKey          id.SenderKey `json:"sender_key"`
+	SenderClaimedKey   id.Ed25519   `json:"sender_claimed_ed25519_key"`
+	ForwardingKeyChain []string     `json:"forwarding_curve25519_key_chain"`
 }
 
 type KeyRequestAction string

--- a/event/type.go
+++ b/event/type.go
@@ -172,9 +172,15 @@ var (
 
 // Device-to-device events
 var (
-	ToDeviceRoomKey          = Type{"m.room_key", ToDeviceEventType}
-	ToDeviceRoomKeyRequest   = Type{"m.room_key_request", ToDeviceEventType}
-	ToDeviceForwardedRoomKey = Type{"m.forwarded_room_key", ToDeviceEventType}
-	ToDeviceEncrypted        = Type{"m.room.encrypted", ToDeviceEventType}
-	ToDeviceRoomKeyWithheld  = Type{"m.room_key.withheld", ToDeviceEventType}
+	ToDeviceRoomKey             = Type{"m.room_key", ToDeviceEventType}
+	ToDeviceRoomKeyRequest      = Type{"m.room_key_request", ToDeviceEventType}
+	ToDeviceForwardedRoomKey    = Type{"m.forwarded_room_key", ToDeviceEventType}
+	ToDeviceEncrypted           = Type{"m.room.encrypted", ToDeviceEventType}
+	ToDeviceRoomKeyWithheld     = Type{"m.room_key.withheld", ToDeviceEventType}
+	ToDeviceVerificationRequest = Type{"m.key.verification.request", ToDeviceEventType}
+	ToDeviceVerificationStart   = Type{"m.key.verification.start", ToDeviceEventType}
+	ToDeviceVerificationAccept  = Type{"m.key.verification.accept", ToDeviceEventType}
+	ToDeviceVerificationKey     = Type{"m.key.verification.key", ToDeviceEventType}
+	ToDeviceVerificationMAC     = Type{"m.key.verification.mac", ToDeviceEventType}
+	ToDeviceVerificationCancel  = Type{"m.key.verification.cancel", ToDeviceEventType}
 )

--- a/event/verification.go
+++ b/event/verification.go
@@ -1,0 +1,130 @@
+// Copyright (c) 2020 Nikos Filippakis
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package event
+
+import (
+	"maunium.net/go/mautrix/id"
+)
+
+type VerificationMethod string
+
+const VerificationMethodSAS VerificationMethod = "m.sas.v1"
+
+// VerificationRequestEventContent represents the content of a m.key.verification.request to_device event.
+// https://matrix.org/docs/spec/client_server/r0.6.0#m-key-verification-request
+type VerificationRequestEventContent struct {
+	// The device ID which is initiating the request.
+	FromDevice id.DeviceID `json:"from_device"`
+	// An opaque identifier for the verification request. Must be unique with respect to the devices involved.
+	TransactionID string `json:"transaction_id"`
+	// The verification methods supported by the sender.
+	Methods []VerificationMethod `json:"methods"`
+	// The POSIX timestamp in milliseconds for when the request was made.
+	Timestamp int64 `json:"timestamp"`
+}
+
+type KeyAgreementProtocol string
+
+const KeyAgreementCurve25519 KeyAgreementProtocol = "curve25519"
+
+type VerificationHashMethod string
+
+const VerificationHashSHA256 VerificationHashMethod = "sha256"
+
+type MACMethod string
+
+const HKDFHMACSHA256 MACMethod = "hkdf-hmac-sha256"
+
+type SASMethod string
+
+const (
+	SASDecimal SASMethod = "decimal"
+	SASEmoji   SASMethod = "emoji"
+)
+
+// VerificationStartEventContent represents the content of a m.key.verification.start to_device event.
+// https://matrix.org/docs/spec/client_server/r0.6.0#m-key-verification-start
+type VerificationStartEventContent struct {
+	// The device ID which is initiating the process.
+	FromDevice id.DeviceID `json:"from_device"`
+	// An opaque identifier for the verification process. Must be unique with respect to the devices involved.
+	TransactionID string `json:"transaction_id"`
+	// The verification method to use.
+	Method VerificationMethod `json:"method"`
+	// The key agreement protocols the sending device understands.
+	KeyAgreementProtocols []KeyAgreementProtocol `json:"key_agreement_protocols"`
+	// The hash methods the sending device understands.
+	Hashes []VerificationHashMethod `json:"hashes"`
+	// The message authentication codes that the sending device understands.
+	MessageAuthenticationCodes []MACMethod `json:"message_authentication_codes"`
+	// The SAS methods the sending device (and the sending device's user) understands.
+	ShortAuthenticationString []SASMethod `json:"short_authentication_string"`
+}
+
+// VerificationAcceptEventContent represents the content of a m.key.verification.accept to_device event.
+// https://matrix.org/docs/spec/client_server/r0.6.0#m-key-verification-accept
+type VerificationAcceptEventContent struct {
+	// An opaque identifier for the verification process. Must be the same as the one used for the m.key.verification.start message.
+	TransactionID string `json:"transaction_id"`
+	// The verification method to use.
+	Method VerificationMethod `json:"method"`
+	// The key agreement protocol the device is choosing to use, out of the options in the m.key.verification.start message.
+	KeyAgreementProtocol KeyAgreementProtocol `json:"key_agreement_protocol"`
+	// The hash method the device is choosing to use, out of the options in the m.key.verification.start message.
+	Hash VerificationHashMethod `json:"hash"`
+	// The message authentication code the device is choosing to use, out of the options in the m.key.verification.start message.
+	MessageAuthenticationCode MACMethod `json:"message_authentication_code"`
+	// The SAS methods both devices involved in the verification process understand. Must be a subset of the options in the m.key.verification.start message.
+	ShortAuthenticationString []SASMethod `json:"short_authentication_string"`
+	// The hash (encoded as unpadded base64) of the concatenation of the device's ephemeral public key (encoded as unpadded base64) and the canonical JSON representation of the m.key.verification.start message.
+	Commitment string `json:"commitment"`
+}
+
+// VerificationKeyEventContent represents the content of a m.key.verification.key to_device event.
+// https://matrix.org/docs/spec/client_server/r0.6.0#m-key-verification-key
+type VerificationKeyEventContent struct {
+	// An opaque identifier for the verification process. Must be the same as the one used for the m.key.verification.start message.
+	TransactionID string `json:"transaction_id"`
+	// The device's ephemeral public key, encoded as unpadded base64.
+	Key string `json:"key"`
+}
+
+// VerificationMacEventContent represents the content of a m.key.verification.mac to_device event.
+// https://matrix.org/docs/spec/client_server/r0.6.0#m-key-verification-mac
+type VerificationMacEventContent struct {
+	// An opaque identifier for the verification process. Must be the same as the one used for the m.key.verification.start message.
+	TransactionID string `json:"transaction_id"`
+	// A map of the key ID to the MAC of the key, using the algorithm in the verification process. The MAC is encoded as unpadded base64.
+	Mac map[id.KeyID]string `json:"mac"`
+	// The MAC of the comma-separated, sorted, list of key IDs given in the mac property, encoded as unpadded base64.
+	Keys string `json:"keys"`
+}
+
+type VerificationCancelCode string
+
+const (
+	VerificationCancelByUser             VerificationCancelCode = "m.user"
+	VerificationCancelByTimeout          VerificationCancelCode = "m.timeout"
+	VerificationCancelUnknownTransaction VerificationCancelCode = "m.unknown_transaction"
+	VerificationCancelUnknownMethod      VerificationCancelCode = "m.unknown_method"
+	VerificationCancelUnexpectedMessage  VerificationCancelCode = "m.unexpected_message"
+	VerificationCancelKeyMismatch        VerificationCancelCode = "m.key_mismatch"
+	VerificationCancelUserMismatch       VerificationCancelCode = "m.user_mismatch"
+	VerificationCancelInvalidMessage     VerificationCancelCode = "m.invalid_message"
+	VerificationCancelAccepted           VerificationCancelCode = "m.accepted"
+)
+
+// VerificationCancelEventContent represents the content of a m.key.verification.cancel to_device event.
+// https://matrix.org/docs/spec/client_server/r0.6.0#m-key-verification-cancel
+type VerificationCancelEventContent struct {
+	// The opaque identifier for the verification process/request.
+	TransactionID string `json:"transaction_id"`
+	// A human readable description of the code. The client should only rely on this string if it does not understand the code.
+	Reason string `json:"reason"`
+	// The error code for why the process/request was cancelled by the user.
+	Code VerificationCancelCode `json:"code"`
+}


### PR DESCRIPTION
* Add ability to ask other devices to forward a room key
* Handle forwarded room keys by saving them to the crypto store when coming from the same user ID
* Handle requests for forwarding room keys from other devices
* Add some types that will be needed for key verification

Currently keys are shared with any device that belongs to the same user ID, however that should change once verification is working to only allow verified devices.