### PR TITLE
Update the Registration struct

### DIFF
--- a/appservice/registration.go
+++ b/appservice/registration.go
@@ -21,7 +21,7 @@ type Registration struct {
 	AppToken        string     `yaml:"as_token"`
 	ServerToken     string     `yaml:"hs_token"`
 	SenderLocalpart string     `yaml:"sender_localpart"`
-	RateLimited     bool       `yaml:"rate_limited,omitempty"`
+	RateLimited     *bool       `yaml:"rate_limited,omitempty"`
 	Namespaces      Namespaces `yaml:"namespaces"`
 	EphemeralEvents bool       `yaml:"de.sorunome.msc2409.push_ephemeral,omitempty"`
 	Protocols       []string   `yaml:"protocols,omitempty"`

--- a/appservice/registration.go
+++ b/appservice/registration.go
@@ -21,9 +21,10 @@ type Registration struct {
 	AppToken        string     `yaml:"as_token"`
 	ServerToken     string     `yaml:"hs_token"`
 	SenderLocalpart string     `yaml:"sender_localpart"`
-	RateLimited     bool       `yaml:"rate_limited"`
+	RateLimited     bool       `yaml:"rate_limited,omitempty"`
 	Namespaces      Namespaces `yaml:"namespaces"`
 	EphemeralEvents bool       `yaml:"de.sorunome.msc2409.push_ephemeral,omitempty"`
+	Protocols       []string   `yaml:"protocols,omitempty"`
 }
 
 // CreateRegistration creates a Registration with random appservice and homeserver tokens.


### PR DESCRIPTION
Add the `protocols` option. Also add `omitempty` to the `rate_limited` option since it's not required to appear in the registration file, and so we fall back to the homeserver's default value (for example Synapse's is `true` so if one wants to keep to default behaviours they probably don't want it to be automatically set to `false`).