### PR TITLE
Implement helpers for fetching user presence status

### DIFF
--- a/client.go
+++ b/client.go
@@ -813,7 +813,7 @@ func (cli *Client) UserTyping(roomID id.RoomID, typing bool, timeout int64) (res
 	return
 }
 
-// GetPresence gets the presence of the user with the specified MXID. See https://matrix.org/docs/spec/client_server/latest#get-matrix-client-r0-presence-userid-status
+// GetPresence gets the presence of the user with the specified MXID. See https://matrix.org/docs/spec/client_server/r0.6.1#get-matrix-client-r0-presence-userid-status
 func (cli *Client) GetPresence(userID id.UserID) (resp *RespPresence, err error) {
 	resp = new(RespPresence)
 	u := cli.BuildURL("presence", userID, "status")
@@ -821,7 +821,7 @@ func (cli *Client) GetPresence(userID id.UserID) (resp *RespPresence, err error)
 	return
 }
 
-// GetPresence gets the user's presence. See https://matrix.org/docs/spec/client_server/latest#get-matrix-client-r0-presence-userid-status
+// GetOwnPresence gets the user's presence. See https://matrix.org/docs/spec/client_server/r0.6.1#get-matrix-client-r0-presence-userid-status
 func (cli *Client) GetOwnPresence() (resp *RespPresence, err error) {
 	return cli.GetPresence(cli.UserID)
 }

--- a/client.go
+++ b/client.go
@@ -813,6 +813,19 @@ func (cli *Client) UserTyping(roomID id.RoomID, typing bool, timeout int64) (res
 	return
 }
 
+// GetPresence gets the presence of the user with the specified MXID. See https://matrix.org/docs/spec/client_server/latest#get-matrix-client-r0-presence-userid-status
+func (cli *Client) GetPresence(userID id.UserID) (resp *RespPresence, err error) {
+	resp = new(RespPresence)
+	u := cli.BuildURL("presence", userID, "status")
+	_, err = cli.MakeRequest("GET", u, nil, resp)
+	return
+}
+
+// GetPresence gets the user's presence. See https://matrix.org/docs/spec/client_server/latest#get-matrix-client-r0-presence-userid-status
+func (cli *Client) GetOwnPresence() (resp *RespPresence, err error) {
+	return cli.GetPresence(cli.UserID)
+}
+
 func (cli *Client) SetPresence(status event.Presence) (err error) {
 	req := ReqPresence{Presence: status}
 	u := cli.BuildURL("presence", cli.UserID, "status")

--- a/responses.go
+++ b/responses.go
@@ -49,7 +49,7 @@ type RespUnbanUser struct{}
 // RespTyping is the JSON response for https://matrix.org/docs/spec/client_server/r0.2.0.html#put-matrix-client-r0-rooms-roomid-typing-userid
 type RespTyping struct{}
 
-// RespPresence is the JSON response for https://matrix.org/docs/spec/client_server/latest#get-matrix-client-r0-presence-userid-status
+// RespPresence is the JSON response for https://matrix.org/docs/spec/client_server/r0.6.1#get-matrix-client-r0-presence-userid-status
 type RespPresence struct {
 	Presence        event.Presence `json:"presence"`
 	LastActiveAgo   int            `json:"last_active_ago"`

--- a/responses.go
+++ b/responses.go
@@ -49,6 +49,14 @@ type RespUnbanUser struct{}
 // RespTyping is the JSON response for https://matrix.org/docs/spec/client_server/r0.2.0.html#put-matrix-client-r0-rooms-roomid-typing-userid
 type RespTyping struct{}
 
+// RespPresence is the JSON response for https://matrix.org/docs/spec/client_server/latest#get-matrix-client-r0-presence-userid-status
+type RespPresence struct {
+	Presence        event.Presence `json:"presence"`
+	LastActiveAgo   int            `json:"last_active_ago"`
+	StatusMsg       string         `json:"status_msg"`
+	CurrentlyActive bool           `json:"currently_active"`
+}
+
 // RespJoinedRooms is the JSON response for https://matrix.org/docs/spec/client_server/r0.4.0.html#get-matrix-client-r0-joined-rooms
 type RespJoinedRooms struct {
 	JoinedRooms []id.RoomID `json:"joined_rooms"`


### PR DESCRIPTION
This PR adds the functions `GetPresence` and `GetOwnPresence` to the `Client` struct, which implement making [`GET /_matrix/client/r0/presence/{userId}/status`](https://matrix.org/docs/spec/client_server/latest#get-matrix-client-r0-presence-userid-status) for the given MXID or the client's MXID, respectively.