### PR TITLE
Use the correct type for presence state constants

### DIFF
--- a/event/ephemeral.go
+++ b/event/ephemeral.go
@@ -49,9 +49,9 @@ func (rr *ReadReceipt) UnmarshalJSON(data []byte) error {
 type Presence string
 
 const (
-	PresenceOnline      = "online"
-	PresenceOffline     = "offline"
-	PresenceUnavailable = "unavailable"
+	PresenceOnline      Presence = "online"
+	PresenceOffline     Presence = "offline"
+	PresenceUnavailable Presence = "unavailable"
 )
 
 // PresenceEventContent represents the content of a m.presence ephemeral event.


### PR DESCRIPTION
While fiddling with presence, I realised `PresenceOnline`m `PresenceOffline` and `PresenceUnavailable` were of type `string` instead of `Presence` (which looks to me like what it should be).