### PR TITLE
url decode for pills

### DIFF
--- a/format/htmlparser.go
+++ b/format/htmlparser.go
@@ -154,10 +154,10 @@ func (parser *HTMLParser) linkToString(node *html.Node, stripLinebreak bool, ctx
 		return str
 	}
 	decoded_href, err := url.QueryUnescape(href)
-	if err == nil {
-		href = decoded_href
+	if err != nil {
+		decoded_href = href
 	}
-	match := MatrixToURL.FindStringSubmatch(href)
+	match := MatrixToURL.FindStringSubmatch(decoded_href)
 	if len(match) == 2 || len(match) == 3 {
 		if parser.PillConverter != nil {
 			mxid := match[1]

--- a/format/htmlparser.go
+++ b/format/htmlparser.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 
 	"golang.org/x/net/html"
+	"net/url"
 )
 
 // MatrixToURL is the regex for parsing matrix.to URLs.
@@ -151,6 +152,10 @@ func (parser *HTMLParser) linkToString(node *html.Node, stripLinebreak bool, ctx
 	href := parser.getAttribute(node, "href")
 	if len(href) == 0 {
 		return str
+	}
+	decoded_href, err := url.QueryUnescape(href)
+	if err == nil {
+		href = decoded_href
 	}
 	match := MatrixToURL.FindStringSubmatch(href)
 	if len(match) == 2 || len(match) == 3 {


### PR DESCRIPTION
Based on the discussion in the room a little bit ago, this PR tries URL decoding links when they come in so they can be properly checked for pill status. In the end the url-encoded string is still sent back.